### PR TITLE
Fixes fixed-size uint8 arrays differential treatment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Unreleased
+------------------
+- Fixes fixed-size uint8 array conversion failure (GitHub issue #5)
+
 0.4.0 (2015-12-13)
 ------------------
 - Adds support for ROS Jade

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(catkin REQUIRED COMPONENTS message_generation roslib rospy rostest 
 add_message_files(
   FILES
   TestArray.msg
+  Uint8Array3TestMessage.msg
+  Uint8ArrayTestMessage.msg
   NOINSTALL
 )
 

--- a/msg/Uint8Array3TestMessage.msg
+++ b/msg/Uint8Array3TestMessage.msg
@@ -1,0 +1,2 @@
+# Fixed size uint8 array for testing purposes
+uint8[3] data

--- a/msg/Uint8ArrayTestMessage.msg
+++ b/msg/Uint8ArrayTestMessage.msg
@@ -1,0 +1,2 @@
+# Size-agnostic uint8 array for testing purposes
+uint8[] data

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -87,7 +87,7 @@ def convert_dictionary_to_ros_message(message_type, dictionary):
     return message
 
 def _convert_to_ros_type(field_type, field_value):
-    if field_type in ros_binary_types:
+    if is_ros_binary_type(field_type, field_value):
         field_value = _convert_to_ros_binary(field_type, field_value)
     elif field_type in ros_time_types:
         field_value = _convert_to_ros_time(field_type, field_value)

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -57,7 +57,7 @@ ros_primitive_types = ['bool', 'byte', 'char', 'int8', 'uint8', 'int16',
                        'uint16', 'int32', 'uint32', 'int64', 'uint64',
                        'float32', 'float64', 'string']
 ros_header_types = ['Header', 'std_msgs/Header', 'roslib/Header']
-ros_binary_types = ['uint8[]', 'char[]']
+ros_binary_types_regexp = re.compile(r'(uint8|char)\[[^\]]*\]')
 
 list_brackets = re.compile(r'\[[^\]]*\]')
 
@@ -150,7 +150,7 @@ def convert_ros_message_to_dictionary(message):
     return dictionary
 
 def _convert_from_ros_type(field_type, field_value):
-    if field_type in ros_binary_types:
+    if is_ros_binary_type(field_type, field_value):
         field_value = _convert_from_ros_binary(field_type, field_value)
     elif field_type in ros_time_types:
         field_value = _convert_from_ros_time(field_type, field_value)
@@ -162,6 +162,25 @@ def _convert_from_ros_type(field_type, field_value):
         field_value = convert_ros_message_to_dictionary(field_value)
 
     return field_value
+
+
+def is_ros_binary_type(field_type, field_value):
+    """ Checks if the field is a binary array one, fixed size or not
+
+    is_ros_binary_type("uint8", 42)
+    >>> False
+    is_ros_binary_type("uint8[]", [42, 18])
+    >>> True
+    is_ros_binary_type("uint8[3]", [42, 18, 21]
+    >>> True
+    is_ros_binary_type("char", 42)
+    >>> False
+    is_ros_binary_type("char[]", [42, 18])
+    >>> True
+    is_ros_binary_type("char[3]", [42, 18, 21]
+    >>> True
+    """
+    return re.search(ros_binary_types_regexp, field_type) is not None
 
 def _convert_from_ros_binary(field_type, field_value):
     field_value = base64.standard_b64encode(field_value)

--- a/test/test_json_message_converter.py
+++ b/test/test_json_message_converter.py
@@ -23,6 +23,22 @@ class TestJsonMessageConverter(unittest.TestCase):
         returned_json = json_message_converter.convert_ros_message_to_json(message)
         self.assertEqual(returned_json, expected_json)
 
+    def test_ros_message_with_uint8_array(self):
+        from rospy_message_converter.msg import Uint8ArrayTestMessage
+        input_data = "".join([chr(i) for i in [97, 98, 99, 100]])
+        expected_json = '{"data": "YWJjZA=="}'  # base64encode("abcd") is YWJjZA==
+        message = Uint8ArrayTestMessage(data=input_data)
+        returned_json = json_message_converter.convert_ros_message_to_json(message)
+        self.assertEqual(returned_json, expected_json)
+
+    def test_ros_message_with_uint8_array(self):
+        from rospy_message_converter.msg import Uint8Array3TestMessage
+        input_data = "".join([chr(i) for i in [97, 98, 99, 100]])
+        expected_json = '{"data": "YWJjZA=="}'  # base64encode("abcd") YWJjZA==
+        message = Uint8Array3TestMessage(data=input_data)
+        returned_json = json_message_converter.convert_ros_message_to_json(message)
+        self.assertEqual(returned_json, expected_json)
+
     def test_json_with_string(self):
         from std_msgs.msg import String
         expected_message = String(data = 'Hello')

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -102,6 +102,22 @@ class TestMessageConverter(unittest.TestCase):
         dictionary = message_converter.convert_ros_message_to_dictionary(message)
         self.assertEqual(dictionary, expected_dictionary)
 
+    def test_ros_message_with_uint8_array(self):
+        from rospy_message_converter.msg import Uint8ArrayTestMessage
+        from base64 import standard_b64encode
+        expected_data = "".join([chr(i) for i in [97, 98, 99, 100]])
+        message = Uint8ArrayTestMessage(data=expected_data)
+        dictionary = message_converter.convert_ros_message_to_dictionary(message)
+        self.assertEqual(dictionary["data"], standard_b64encode(expected_data))
+
+    def test_ros_message_with_3uint8_array(self):
+        from rospy_message_converter.msg import Uint8Array3TestMessage
+        from base64 import standard_b64encode
+        expected_data = "".join([chr(i) for i in [97, 98, 99, 100]])
+        message = Uint8Array3TestMessage(data=expected_data)
+        dictionary = message_converter.convert_ros_message_to_dictionary(message)
+        self.assertEqual(dictionary["data"], standard_b64encode(expected_data))
+
     def test_ros_message_with_int16(self):
         from std_msgs.msg import Int16
         expected_dictionary = { 'data': -0x7FFF }


### PR DESCRIPTION
## Problem
JSON conversion of fixed size uint8 arrays fails because fixed size uint8 arrays are incorrectly considered "not binary type", hence not base64 encoded. This is a known issue, labeled as #5

## Troubleshooting
This was traced back to the `field_type in ros_binary_types` check which doesn't succeed for fixed sized arrays, cascading the if-else ladder to ` _convert_from_ros_array()` call, mislabeled as primitive type "array of uint8".

## Solution
- Added tests to prove the unintended behavior
- Fixed issue with a regex matching