### PR TITLE
Remove dependency on ROS master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Change Log
 Unreleased
 ------------------
 - Fixes fixed-size uint8 array conversion failure (GitHub issue #5)
+- Removes dependency on ROS master in tests (all tests are now unit
+  tests)
 
 0.4.0 (2015-12-13)
 ------------------

--- a/test/test_json_message_converter.py
+++ b/test/test_json_message_converter.py
@@ -15,8 +15,8 @@ class TestJsonMessageConverter(unittest.TestCase):
 
     def test_ros_message_with_header(self):
         from std_msgs.msg import Header
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_json = '{{"stamp": {{"secs": {0}, "nsecs": {1}}}, "frame_id": "my_frame", "seq": 3}}'\
             .format(now_time.secs, now_time.nsecs)
         message = Header(stamp = now_time, frame_id = 'my_frame', seq = 3)
@@ -48,8 +48,8 @@ class TestJsonMessageConverter(unittest.TestCase):
 
     def test_json_with_header(self):
         from std_msgs.msg import Header
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_message = Header(
             stamp = now_time,
             frame_id = 'my_frame',

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 import unittest
 import rospy
-import rostest
-from pprint import pprint
 from rospy_message_converter import message_converter
 
 class TestMessageConverter(unittest.TestCase):
@@ -73,8 +71,8 @@ class TestMessageConverter(unittest.TestCase):
 
     def test_ros_message_with_header(self):
         from std_msgs.msg import Header
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_dictionary = {
             'stamp': { 'secs': now_time.secs, 'nsecs': now_time.nsecs },
             'frame_id' : 'my_frame',
@@ -169,8 +167,8 @@ class TestMessageConverter(unittest.TestCase):
 
     def test_ros_message_with_time(self):
         from std_msgs.msg import Time
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_dictionary = {
             'data': { 'secs': now_time.secs, 'nsecs': now_time.nsecs }
         }
@@ -275,8 +273,8 @@ class TestMessageConverter(unittest.TestCase):
 
     def test_dictionary_with_header(self):
         from std_msgs.msg import Header
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_message = Header(
             stamp = now_time,
             frame_id = 'my_frame',
@@ -292,8 +290,8 @@ class TestMessageConverter(unittest.TestCase):
 
     def test_dictionary_with_header_with_no_prefix(self):
         from std_msgs.msg import Header
-        rospy.init_node('time_node')
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_message = Header(
             stamp = now_time,
             frame_id = 'my_frame',
@@ -372,7 +370,8 @@ class TestMessageConverter(unittest.TestCase):
 
     def test_dictionary_with_time(self):
         from std_msgs.msg import Time
-        now_time = rospy.Time.now()
+        from time import time
+        now_time = rospy.Time(time())
         expected_message = Time(data=now_time)
         dictionary = {
             'data': {
@@ -427,4 +426,5 @@ class TestMessageConverter(unittest.TestCase):
 PKG = 'rospy_message_converter'
 NAME = 'test_message_converter'
 if __name__ == '__main__':
+    import rostest
     rostest.unitrun(PKG, NAME, TestMessageConverter)


### PR DESCRIPTION
None of the tests in this library _really_ require a ROS node with a ROS master, as the tests are self-contained to statically-compiled ROS messages. We essentially have unit tests here.

By changing the calls to `rospy.Time.now()` to ` rospy.Time(time.time())`, we remove the need for `rospy.init_node`, remove the imports of `rostest`, and change the tests to be unit tests (runs faster because not a ROS node, smaller footprint).

This is done at the _meager_ cost of losing the hypothetical benefit of fiddling with ROS' Clock independently of the Wall clock.